### PR TITLE
feat(example): add basic example to use the VRF lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,20 @@
 [package]
 name = "vrf"
 version = "0.1.0"
+description = "An implementation of Verifiable Random Functions (VRFs)"
+keywords = ["vrf", "ecvrf", "elliptic curve", "secp256k1", "p256", "k163"]
+categories = ["algorithms", "cryptography"]
+license = "GPL-3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
+homepage = "https://github.com/witnet/vrf-rs"
+documentation = "https://docs.rs/vrf/"
+repository = "https://github.com/witnet/vrf-rs"
+readme = "README.md"
+exclude = ["/.travis.yml"]
+
+[badges]
+travis-ci = { repository = "witnet/vrf-rs", branch = "master" }
 
 [dependencies]
 failure = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,59 @@
 # vrf-rs
+[![](https://img.shields.io/crates/v/vrf.svg)](https://crates.io/crates/vrf) [![](https://docs.rs/vrf/badge.svg)](https://docs.rs/vrf) [![](https://travis-ci.com/witnet/vrf-rs.svg?branch=master)](https://travis-ci.com/witnet/vrf-rs)
 
 `vrf-rs` is an open source implementation of Verifiable Random Functions (VRFs) written in Rust.
 
-_DISCLAIMER: This is experimental software running on experimental network protocols. Be careful!_
+_DISCLAIMER: This is experimental software. Be careful!_
+
+## Elliptic Curve VRF
+
+This module uses the OpenSSL library to offer Elliptic Curve Verifiable Random Function (VRF) functionality.
+
+It follows the algorithms described in:
+
+* [VRF-draft-04](https://tools.ietf.org/pdf/draft-irtf-cfrg-vrf-04)
+* [RFC6979](https://tools.ietf.org/html/rfc6979)
+
+Currently the supported cipher suites are:
+
+* `P256_SHA256_TAI`: the aforementioned algorithms with `SHA256` and the `NIST P-256` curve.
+* `K163_SHA256_TAI`: the aforementioned algorithms with `SHA256` and the `NIST K-163` curve.
+* `SECP256K1_SHA256_TAI`: the aforementioned algorithms with `SHA256` and the `secp256k1` curve.
+
+### Example
+
+Create and verify a VRF proof by using the cipher suite `SECP256K1_SHA256_TAI`:
+
+```rust
+    use vrf::VRF;
+    use vrf::openssl::{CipherSuite, ECVRF};
+
+    // Initialization of VRF context by providing a curve
+    let mut vrf = ECVRF::from_suite(CipherSuite::SECP256K1_SHA256_TAI)?;
+    
+    // `prove` returns a `Result` with the VRF proof as `Vec<u8>`
+    let proof = vrf.prove(&secret_key, &message)?;
+    
+    // `verify` returns a `Result` with the VRF hash output as `Vec<u8>`
+    let proof_hash = vrf.verify(&public_key, &pi, &message);
+```
+
+## Adding unsupported cipher suites
+
+This library defines a `VRF` trait which can be extended in order to use different curves and algorithms.
+
+```rust
+pub trait VRF<PublicKey, SecretKey> {
+    type Error;
+
+    fn prove(&mut self, x: SecretKey, alpha: &[u8]) -> Result<Vec<u8>, Self::Error>;
+
+    fn verify(&mut self, y: PublicKey, pi: &[u8], alpha: &[u8]) -> Result<Vec<u8>, Self::Error>;
+}
+```
 
 ## License
 
 vrf-rs is published under the [GNU General Public License v3.0][license].
+
+[license]: https://github.com/witnet/vrf-rs/blob/master/LICENSE

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,31 @@
+use vrf::openssl::{CipherSuite, ECVRF};
+use vrf::VRF;
+
+fn main() {
+    let mut vrf = ECVRF::from_suite(CipherSuite::SECP256K1_SHA256_TAI).unwrap();
+    // Secret Key (labelled as x)
+    let secret_key =
+        hex::decode("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721").unwrap();
+    let public_key = vrf.derive_public_key(&secret_key).unwrap();
+
+    // Data: ASCII "sample"
+    let message: &[u8] = b"sample";
+    let pi = vrf.prove(&secret_key, &message).unwrap();
+    println!("Generated VRF proof: {}", hex::encode(&pi));
+
+    // Compute VRF hash ouput
+    let hash = vrf.proof_to_hash(&pi).unwrap();
+
+    // Verify VRF proof (returns VRF hash output)
+    let beta = vrf.verify(&public_key, &pi, &message);
+
+    match beta {
+        Ok(beta) => {
+            println!("VRF proof is valid!\nHash output: {}", hex::encode(&beta));
+            assert_eq!(hash, beta);
+        }
+        Err(e) => {
+            println!("VRF proof is not valid: {}", e);
+        }
+    }
+}

--- a/src/openssl/mod.rs
+++ b/src/openssl/mod.rs
@@ -1,4 +1,4 @@
-//! Module that uses the OpenSSL library to offer Elliptic Curve Verifiable Random Function (VRF) funcionality.
+//! Module that uses the OpenSSL library to offer Elliptic Curve Verifiable Random Function (VRF) functionality.
 //! This module follows the algorithms described in [VRF-draft-04](https://tools.ietf.org/pdf/draft-irtf-cfrg-vrf-04) and [RFC6979](https://tools.ietf.org/html/rfc6979).
 //!
 //! In particular, it provides:


### PR DESCRIPTION
This PR includes a basic example that shows how to use the VRF library.