### PR TITLE
Adapt VRF library to VRF-draft-05

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrf"
-version = "0.2.0"
+version = "0.2.1"
 description = "Fast and extensible Verifiable Random Function (VRF) library; currently supporting secp256k1, secp256r1 and sect163k1 curves"
 keywords = ["vrf", "ecvrf", "secp256k1", "p256", "k163"]
 categories = ["algorithms", "cryptography"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This module uses the OpenSSL library to offer Elliptic Curve Verifiable Random F
 
 It follows the algorithms described in:
 
-* [VRF-draft-04](https://tools.ietf.org/pdf/draft-irtf-cfrg-vrf-04)
+* [VRF-draft-05](https://tools.ietf.org/pdf/draft-irtf-cfrg-vrf-05)
 * [RFC6979](https://tools.ietf.org/html/rfc6979)
 
 Currently the supported cipher suites are:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! It follows the algorithms described in:
 //!
-//! * [VRF-draft-04](https://tools.ietf.org/pdf/draft-irtf-cfrg-vrf-04)
+//! * [VRF-draft-05](https://tools.ietf.org/pdf/draft-irtf-cfrg-vrf-05)
 //! * [RFC6979](https://tools.ietf.org/html/rfc6979)
 //!
 //! Currently the supported cipher suites are:


### PR DESCRIPTION
This PR adapts the library to the latest [VRF 05 draft version](https://tools.ietf.org/pdf/draft-irtf-cfrg-vrf-05)
- A hash of the H point is performed before calculating the nonce.
- The test have been adapted to match the new draft.

Closes #13 

